### PR TITLE
Update guestbook deployment image tag to v4

### DIFF
--- a/kustomize-guestbook/guestbook-ui-deployment.yaml
+++ b/kustomize-guestbook/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-        - image: gcr.io/google-samples/gb-frontend:v3
+        - image: gcr.io/google-samples/gb-frontend:v4
           name: guestbook-ui
           ports:
             - containerPort: 80


### PR DESCRIPTION
Update the guestbook deployment to use image tag v4 for gb-frontend.

- Changes image tag in kustomize-guestbook/guestbook-ui-deployment.yaml from v3 to v4.