### PR TITLE
Update guestbook-ui to image tag v4

### DIFF
--- a/kustomize-guestbook/guestbook-ui-deployment.yaml
+++ b/kustomize-guestbook/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-        - image: gcr.io/google-samples/gb-frontend:v3
+        - image: gcr.io/google-samples/gb-frontend:v4
           name: guestbook-ui
           ports:
             - containerPort: 80


### PR DESCRIPTION
This PR updates the guestbook-ui deployment to use the image gcr.io/google-samples/gb-frontend:v4 for improved features and stability.