### PR TITLE
Update guestbook-ui container image tag to v4

### DIFF
--- a/kustomize-guestbook/guestbook-ui-deployment.yaml
+++ b/kustomize-guestbook/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-        - image: gcr.io/google-samples/gb-frontend:v3
+        - image: gcr.io/google-samples/gb-frontend:v4
           name: guestbook-ui
           ports:
             - containerPort: 80


### PR DESCRIPTION
This PR updates the Deployment manifest for guestbook-ui to set the container image tag to v4.
- Bumps image tag from v3 to v4 in kustomize-guestbook/guestbook-ui-deployment.yaml