### PR TITLE
Bump guestbook-ui replicas to 2

### DIFF
--- a/kustomize-guestbook/guestbook-ui-deployment.yaml
+++ b/kustomize-guestbook/guestbook-ui-deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: guestbook-ui
 spec:
-  replicas: 1
+  replicas: 2
   revisionHistoryLimit: 3
   selector:
     matchLabels:


### PR DESCRIPTION
Increase guestbook-ui Deployment replicas from 1 to 2 for better availability.

- This PR updates guestbook-ui-deployment.yaml to set replicas to 2.
- Please review and merge if acceptable.